### PR TITLE
Add disk IO metrics and fix hardware page layout

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,8 +9,17 @@
 </section>
 <div class="panel">
   <div class="hd"><div>实时指标（SSE）</div><div class="tag">每 2 秒更新</div></div>
-  <div class="bd"><div>CPU 实时 <span id="cpu_rt">--%</span> | GPU 实时 <span id="gpu_rt">--%</span></div></div>
+  <div class="bd"><div>CPU 实时 <span id="cpu_rt">--%</span> | GPU 实时 <span id="gpu_rt">--%</span> | 磁盘 IO <span id="disk_rt">--/-- MB/s</span></div></div>
 </div>
+<div class="panel">
+  <div class="hd"><div>CPU 使用率历史</div></div>
+  <div class="bd"><canvas id="cpuChart" height="100"></canvas></div>
+</div>
+<div class="panel">
+  <div class="hd"><div>磁盘 IO（MB/s）</div></div>
+  <div class="bd"><canvas id="diskChart" height="100"></canvas></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
     const $ = (id) => document.getElementById(id);
@@ -23,9 +32,37 @@
       $('al').textContent  = d.alerts;
     });
 
+    const cpuCtx = document.getElementById('cpuChart').getContext('2d');
+    const diskCtx = document.getElementById('diskChart').getContext('2d');
+    const cpuChart = new Chart(cpuCtx, {
+      type: 'line',
+      data: { labels: [], datasets: [{ label: 'CPU %', data: [], borderColor: '#3b82f6', tension: .3 }]},
+      options: { animation: false, scales: { y: { beginAtZero: true, max: 100 } } }
+    });
+    const diskChart = new Chart(diskCtx, {
+      type: 'line',
+      data: { labels: [], datasets: [
+        { label: '读 MB/s', data: [], borderColor: '#16a34a', tension: .3 },
+        { label: '写 MB/s', data: [], borderColor: '#b91c1c', tension: .3 }
+      ]},
+      options: { animation: false, scales: { y: { beginAtZero: true } } }
+    });
+    function addData(chart, label, vals) {
+      chart.data.labels.push(label);
+      chart.data.datasets.forEach((ds, i) => ds.data.push(vals[i]));
+      if (chart.data.labels.length > 30) {
+        chart.data.labels.shift();
+        chart.data.datasets.forEach(ds => ds.data.shift());
+      }
+      chart.update();
+    }
     mountSSE('/events/metrics', d => {
       $('cpu_rt').textContent = d.cpu + '%';
       $('gpu_rt').textContent = d.gpu + '%';
+      $('disk_rt').textContent = d.disk_read.toFixed(1) + '/' + d.disk_write.toFixed(1) + ' MB/s';
+      const t = new Date().toLocaleTimeString();
+      addData(cpuChart, t, [d.cpu]);
+      addData(diskChart, t, [d.disk_read, d.disk_write]);
     });
   });
 </script>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -1,24 +1,32 @@
 {% extends "base.html" %}
-{% block title %}硬件与系�?· 一体机监控系统{% endblock %}
+{% block title %}硬件与系统 · 一体机监控系统{% endblock %}
 {% block content %}
 <div class="panel"><div class="hd"><div>系统摘要</div><div class="tag" id="uptime">--</div></div>
 <div class="bd">
   <div class="kpis">
-    <div class="kpi"><div class="label">主机�?/div><div class="value" id="host">--</div></div>
+    <div class="kpi"><div class="label">主机名</div><div class="value" id="host">--</div></div>
     <div class="kpi"><div class="label">操作系统</div><div class="value" id="os">--</div></div>
     <div class="kpi"><div class="label">CPU 线程</div><div class="value" id="cpu">--</div></div>
     <div class="kpi"><div class="label">内存总量</div><div class="value" id="mem">--</div></div>
   </div>
 </div></div>
 <script>
-function secToStr(s){ s=+s||0;const d=Math.floor(s/86400);s%=86400;const h=Math.floor(s/3600);s%=3600;const m=Math.floor(s/60);return (d?d+'�?':'')+h+'小时'+m+'�?; }
+function secToStr(s){
+  s = +s || 0;
+  const d = Math.floor(s/86400);
+  s %= 86400;
+  const h = Math.floor(s/3600);
+  s %= 3600;
+  const m = Math.floor(s/60);
+  return (d ? d + '天' : '') + h + '小时' + m + '分';
+}
 window.addEventListener('DOMContentLoaded', ()=>{
   apiGet('/api/hardware/summary').then(d=>{
     host.textContent = d.hostname;
     os.textContent = d.os + ' ' + d.kernel + ' ('+d.arch+')';
     cpu.textContent = d.cpu_physical+'C / '+d.cpu_logical+'T';
     mem.textContent = d.mem_total_gb+' GB';
-    uptime.textContent = '已运�?' + secToStr(d.uptime_seconds);
+    uptime.textContent = '已运行 ' + secToStr(d.uptime_seconds);
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- extend metrics SSE with disk IO rates and display live charts on dashboard
- show CPU history and new disk IO chart without setXLabels error
- tidy hardware summary layout and fix uptime formatting

## Testing
- `python -m py_compile backend/app.py`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c12f50d7e4832f9d93a8357da561da